### PR TITLE
slight modification of step-30

### DIFF
--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -568,13 +568,13 @@ namespace Step30
                     // situation of our cell and the neighbor we want to treat
                     // only one half, so that each face is considered only
                     // once. Thus we have the additional condition, that the
-                    // cell with the lower index does the work. In the rare
-                    // case that both cells have the same index, the cell with
-                    // lower level is selected.
+                    // cell with the higher level does the work. In the rare
+                    // case that both cells have the same level, the cell with
+                    // lower index is selected.
                     if (!cell->neighbor_is_coarser(face_no) &&
-                        (neighbor->index() > cell->index() ||
-                         (neighbor->level() < cell->level() &&
-                          neighbor->index() == cell->index())))
+                        (neighbor->level() < cell->level() ||
+                         (neighbor->index() > cell->index() &&
+                          neighbor->level() == cell->level())))
                       {
                         // Here we know, that the neighbor is not coarser so we
                         // can use the usual @p neighbor_of_neighbor


### PR DESCRIPTION
The active cell selection rule doesn't work in 1D problems,
but works by a slight modification.
The point is, in a 1D problem, there are no actual sub-surfaces, a surface can not see
any refined neighbor surfaces.
The old selection rule would easily choose a non-active neighbor, but the new rule can avoid it.